### PR TITLE
Fix set up instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
 
 	``` bash
 	git clone https://github.com/zakariaGatter/xbps-hist.git
-    cd xbps-hist
-    git checkout tags/v0.1.2
+	cd xbps-hist
+	git checkout tags/v0.1.2
 	mkdir -p ~/.local/bin
-	cp xbps-hist/bin/xbps-hist ~/.local/bin
+	cp bin/xbps-hist ~/.local/bin
 	chmod +x ~/.local/bin/xbps-hist
 	```
 


### PR DESCRIPTION
Already cd-ed into the xbps-hist dir earlier, causing the copy to fail.